### PR TITLE
fix: editorial review — the-future-of-truth

### DIFF
--- a/_posts/2025-10-30-the-future-of-truth.md
+++ b/_posts/2025-10-30-the-future-of-truth.md
@@ -3,7 +3,7 @@ layout: post
 title: The Future of Truth
 date: 2025-10-30 23:44:00 +0000
 categories: review book
-version: 1.0.0
+version: 1.0.1
 ---
 
 Herzog's last book really stuck with me.
@@ -21,7 +21,7 @@ This line of thought never led anywhere productive, though.
 Just to a kind of grumpy sniff at those who reach for the real.
 
 Herzog returns to tell us that in an age of ever-easier fabrication, a reach back to Vérité brings no truth.
-Only 'accountants' truth'; he seeks an 'ecstatic truth'.
+Only 'accountant's truth'; he seeks an 'ecstatic truth'.
 In his 1999 manifesto, he described this as:
 > “There are deeper strata of truth in cinema, and there is such a thing as poetic, ecstatic truth. It is mysterious and elusive, and can be reached only through fabrication and imagination and stylization.”
 
@@ -39,6 +39,3 @@ Ecstatic truth might burn bright, care less about the nitpicking details in favo
 
 Aren't we talking about a tool demagogues the world over have employed with the shattering force of their rhetoric?
 Is the ecstasy the important bit, and the truth or lie of it a secondary concern?
-Aren't we talking about a tool the demegougs the world over have employed with the shattering force of their rhetoric?
-
-Is the Ecstasy the important bit and the truth or lie of it a secondary concern?


### PR DESCRIPTION
## Editorial review: 2025-10-30-the-future-of-truth

### Copy-editor fixes
- **Apostrophe**: `accountants' truth` → `accountant's truth` (possessive)
- **Duplicate paragraph removed**: Lines 42–45 were a draft duplicate of lines 40–41, with a misspelling ("demegougs") and errant capitalisation ("Ecstasy") — removed in favour of the clean version

### Fact-check
- Herzog's Minnesota Declaration (1999) quote confirmed exact against primary source
- No corrections required

Version bump: 1.0.0 → 1.0.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)