### PR TITLE
fix: editorial review — how-to-survive-a-crisis

### DIFF
--- a/_posts/2025-11-02-how-to-survive-a-crisis.md
+++ b/_posts/2025-11-02-how-to-survive-a-crisis.md
@@ -3,11 +3,11 @@ layout: post
 title: How to Survive a Crisis
 date: 2025-11-02 23:03:00 +0000
 categories: review book
-version: 1.0.0
+version: 1.0.1
 ---
 
 A manual for crisis.
-One I'll return to I'm ever in the midst of one.
+One I'll return to if I'm ever in the midst of one.
 
 The book offers a distinction between:
 
@@ -19,30 +19,30 @@ When they do occur, careful advanced planning can be invoked to address them.
 
 The response need not be entirely novel, you can work from those plans. An emergency shouldn't also require a wholesale re-thinking of a system.
 
-With a good mind for nightmares you can likely anticipate a lot of bad things, but what you prepare for is grounded in the langauge of risk. There's a proportionality principle here, with liklihood and impact guiding where time is well spent.
+With a good mind for nightmares you can likely anticipate a lot of bad things, but what you prepare for is grounded in the language of risk. There's a proportionality principle here, with likelihood and impact guiding where time is well spent.
 
 An emergency may be bad, but it differs from the others in using that planning to make the situation controllable. So here we are concerned with the creative foresight to anticipate consequence, balanced as risks, with a quality of preparation and rehersal to ensure those plans actually work.
 
 ### Crisis
 
-An escalation from emergency, it's an unsable situation you don't control featuring high levels of uncertainty.
+An escalation from emergency, it's an unstable situation you don't control featuring high levels of uncertainty.
 
-As Ormand puts it in an [interview][springer-interview]:
+As Omand puts it in an [interview][springer-interview]:
 
 > It is characteristic of a crisis that the person in charge doesn’t immediately know what to do. If they did, they would press the button, their emergency plans would swing into action, the emergency services would turn up at the front door, and it would be dealt with, painful though it might be.
 
 Causes may be unclear, events unanticipated or a novel variant exceeding past preparations.
-Standard protocols may fail or a leavers that appeared solid don't work when pulled.
+Standard protocols may fail or a levers that appeared solid don't work when pulled.
 How severe the crisis is will vary based on Intensity, Extent and Duration.
-Ormand shortens this to IED, a pun that recalls the military jargon for improvised explosive devices.
+Omand shortens this to IED, a pun that recalls the military jargon for improvised explosive devices.
 
-Crisis is an inevitably testing moment, but not a moment for dispair. There are opportuntiies to survive long enough to regain a measure of control.
+Crisis is an inevitably testing moment, but not a moment for despair. There are opportunities to survive long enough to regain a measure of control.
 
 This can be helped by early recognition of the seriousness of a situation, mobilising what resources you have to engage the problem, careful handling of uncertainty, considering personal resilience and learning lessons as you go.
 
-The book is mostly about crisis and I think is designed to challenge any leader who thinks they are fully prepared for what is to come. The loss of control returns time and again.Crisis isn't something that can be managed in the same way as an emergency.
+The book is mostly about crisis and I think is designed to challenge any leader who thinks they are fully prepared for what is to come. The loss of control returns time and again. Crisis isn't something that can be managed in the same way as an emergency.
 
-The book isn't fatalistic though, there's still an opportunity presented here. If a crisis can be navigated or survived there may be opportunities to deescalate it back to to a emergency, with a return to the manageable.
+The book isn't fatalistic though, there's still an opportunity presented here. If a crisis can be navigated or survived there may be opportunities to deescalate it back to an emergency, with a return to the manageable.
 
 On the other side, there's the risk that poor handling could see a slide into disaster.
 
@@ -64,12 +64,12 @@ Here you go beyond trying to survive the crisis towards a focus on damage limita
 ---
 
 The book could be a bit dry for anyone not already fascinated by the field.
-I gained confidence as I read through, Ormand says sensible technical things at the margins of his main points that suggest he's drawing from a broad range of ideas. Where those ideas touched on fields I know well as a software developer, I found myself heartened and agreed, taking that confidence into areas I knew less of.
+I gained confidence as I read through, Omand says sensible technical things at the margins of his main points that suggest he's drawing from a broad range of ideas. Where those ideas touched on fields I know well as a software developer, I found myself heartened and agreed, taking that confidence into areas I knew less of.
 
 It speaks the language of ["normal accidents"][wikipedia-normal-accidents], complexity and coupling, testing and drills.
 All areas that resonate a lot with me right now.
 
-I think there's a tendancy to ascribe leaders and orgnisations in every field with broad powers. So when things go wrong, it appears as negiligence or malaice. Ormand rightly holds these groups to high standards in preparing and mitigating the worst to protect life. However it also suggests something wild inherent to this complex and interdepndent world in which we live. Crisis and disaster will come for all given time. The book suggests survival is not to be taken lightly.
+I think there's a tendency to ascribe leaders and organisations in every field with broad powers. So when things go wrong, it appears as negligence or malice. Omand rightly holds these groups to high standards in preparing and mitigating the worst to protect life. However it also suggests something wild inherent to this complex and interdependent world in which we live. Crisis and disaster will come for all given time. The book suggests survival is not to be taken lightly.
 
 [springer-interview]: https://link.springer.com/article/10.1007/s12115-024-00998-2
 [wikipedia-normal-accidents]: https://en.wikipedia.org/wiki/Normal_Accidents


### PR DESCRIPTION
## Editorial review: 2025-11-02-how-to-survive-a-crisis

### Copy-editor fixes (14 errors)
Misspellings: language, likelihood, unstable, levers, despair, opportunities, tendency, organisations, negligence, malice, interdependent; missing space after full stop; duplicate word ("to to"); missing "if"

### Fact-checker
- **Author name corrected**: "Ormand" → "Omand" (David Omand) — 4 instances throughout the post
- Springer interview quote corroborated via ResearchGate PDF
- Full title confirmed: *How to Survive a Crisis: Lessons in Resilience and Avoiding Disaster* (Penguin, 2023/2024)

Version bump: 1.0.0 → 1.0.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)