### PR TITLE
fix: editorial review — the-seven-rules-of-trust

### DIFF
--- a/_posts/2026-02-11-the-seven-rules-of-trust.md
+++ b/_posts/2026-02-11-the-seven-rules-of-trust.md
@@ -14,10 +14,10 @@ In some ways, this made it a nice read but not an earthshaking one for me.
 
 Though I suspect it's because he's preaching to the converted.
 
-Along the way it was nice to hear something of the project's history, more of it's community and it's relentless focus on being "an encyclopedia".
+Along the way it was nice to hear something of the project's history, more of its community and its relentless focus on being "an encyclopedia".
 
-I remember my sixth form history teacher warning us "not to trust Wikipeida, read the books, its inaccuarate and could be written by anyone". I suspect until shortly before he'd have been right about that. From then, until now however it's a beacon of trust and reliabiltiy.
+I remember my sixth form history teacher warning us "not to trust Wikipedia, read the books, it's inaccurate and could be written by anyone". I suspect until shortly before he'd have been right about that. From then, until now however it's a beacon of trust and reliability.
 
-Now, as the AI LLM tools emerge (that would have never been possible without Wikipeida), I feel like I'd be the guy saying "don't trust the LLM, click through to the wikipedia page and read that to verify".
+Now, as the AI LLM tools emerge (that would have never been possible without Wikipedia), I feel like I'd be the guy saying "don't trust the LLM, click through to the wikipedia page and read that to verify".
 
 Hopefully that statement stands the test of time a bit better.

--- a/_posts/2026-02-11-the-seven-rules-of-trust.md
+++ b/_posts/2026-02-11-the-seven-rules-of-trust.md
@@ -3,7 +3,7 @@ layout: post
 title: The Seven Rules of Trust
 date: 2026-02-11T22:32:00.000+00:00
 categories: review book
-version: 1.0.0
+version: 1.0.1
 ---
 
 A short book, and one that felt homey.


### PR DESCRIPTION
## Editorial review: 2026-02-11-the-seven-rules-of-trust

### Copy-editor (5 errors)
- "it's" → "its" (possessive, L17 ×2)
- "Wikipeida" → "Wikipedia" (L19, L21)
- "its inaccuarate" → "it's inaccurate" (L19)
- "reliabiltiy" → "reliability" (L19)

### Fact-check
- Jimmy Wales as Wikipedia co-founder confirmed
- *The Seven Rules of Trust: A Blueprint for Building Things That Last* by Jimmy Wales (Crown) confirmed via Calibre

Version bump: 1.0.0 → 1.0.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)