### PR TITLE
fix: skip PR when pipeline finds no changes

### DIFF
--- a/.claude/agents/coordinator.md
+++ b/.claude/agents/coordinator.md
@@ -133,7 +133,9 @@ After all agents have run, read the tmp files and produce a consolidated summary
 {Any open items — e.g. claims that could not be verified}
 ```
 
-Ask the user: "Shall I open a pull request for these changes?"
+If no changes were made to the source file (no copy errors, no fact-checker corrections), **do not open a PR**. Update the state registry and tell the user the post was clean. Skip the pull request section entirely.
+
+Otherwise, ask the user: "Shall I open a pull request for these changes?"
 
 ## Opening the pull request
 


### PR DESCRIPTION
## Summary
If the pipeline finds no copy errors and no fact-checker corrections, the coordinator now skips opening a PR entirely. Clean posts have nothing to review and the `.tmp/` output is gitignored anyway.

Prompted by #133 and #134 being opened unnecessarily for clean posts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)