### PR TITLE
fix: editorial review — life-and-fate

### DIFF
--- a/_posts/2025-11-09-life-and-fate.md
+++ b/_posts/2025-11-09-life-and-fate.md
@@ -3,7 +3,7 @@ layout: post
 title: Life and Fate
 date: 2025-11-09T20:36:00.000+00:00
 categories: review book
-version: 1.0.0
+version: 1.0.1
 ---
 
 I have a growing sense of urgency to understand the totalitarian.

--- a/_posts/2025-11-09-life-and-fate.md
+++ b/_posts/2025-11-09-life-and-fate.md
@@ -21,9 +21,9 @@ There were striking scenes - in Stalingrad, physics institutes, everyday homes.
 The size of the cast and my poor grasp of Russian naming conventions made for a book to wade through at times.
 
 Between the tightening walls of history, Grossman focuses conspicuously on the domestic, small and interpersonal moments.
-Perhaps this is truer to most experience of them. World-historic events glimpsed from a kitchen table or a window up the street
+Perhaps this is truer to most experience of them. World-historic events glimpsed from a kitchen table or a window up the street.
 
 Small kindnesses and care appear myriad, and despite their times.
 The cruelties - the ghettos, political prisons, anti-semitism, brutalities of war, opportunism, treatment of women - a mix; product of their times but often remaining a choice of those who carry it out.
 
-I think Grossman must have had a faith of those human acts, even when the larger organising principles and moral character of it's supporters fail around them.
+I think Grossman must have had a faith of those human acts, even when the larger organising principles and moral character of its supporters fail around them.


### PR DESCRIPTION
## Editorial review: 2025-11-09-life-and-fate

### Copy-editor (2 errors)
- Missing full stop (L24)
- "it's" → "its" (possessive, L29)

### Fact-check
- *Life and Fate* by Vasily Grossman (National Geographic Books) confirmed via Calibre
- Grossman's *Stalingrad* companion novel confirmed
- Battle of Stalingrad setting confirmed

Version bump: 1.0.0 → 1.0.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)