### PR TITLE
fix: editorial review — hayeks-bastards

### DIFF
--- a/_posts/2025-12-22-hayeks-bastards.md
+++ b/_posts/2025-12-22-hayeks-bastards.md
@@ -3,7 +3,7 @@ layout: post
 title: Hayek's Bastards
 date: 2025-12-23T19:00.000+00:00
 categories: review book
-version: 1.0.0
+version: 1.0.1
 ---
 
 I'd read Crack-Up Capitalism earlier in 2025 and felt like returning to Quinn's books.

--- a/_posts/2025-12-22-hayeks-bastards.md
+++ b/_posts/2025-12-22-hayeks-bastards.md
@@ -6,7 +6,7 @@ categories: review book
 version: 1.0.0
 ---
 
-I'd read Crack Up Capitalism earlier in 2025 and felt like returning to Quinn's books.
+I'd read Crack-Up Capitalism earlier in 2025 and felt like returning to Quinn's books.
 
 This book confirms his role for me as an excellent chronicler of the rise of the populist right globally. He achieves this by a much closer reading than I feel I get anywhere else. Someone who takes their conferences, books, speeches and networks of personal relationships seriously.
 
@@ -15,7 +15,7 @@ Given the growing role of these movements, the moment to ignore or casually char
 
 Crack Up Capitalism traced the movements desire to break the world into smaller and smaller zones of sovereignty where exceptional orders can be tested. Here we're looking at a genealogy. Where did they come from? Who paved the way?
 
-The answer is unexpected for me, I would have placed the populist right of the US Tea Party as a kind of revolt against the existing right. In Hayek's Bastards places them as more radical offspring. Emerging from within a claim to Hayek's legacy but ditching the parts of the argument that held to liberal constitutionality.
+The answer is unexpected for me, I would have placed the populist right of the US Tea Party as a kind of revolt against the existing right. Hayek's Bastards places them as more radical offspring. Emerging from within a claim to Hayek's legacy but ditching the parts of the argument that held to liberal constitutionality.
 
 Instead this generation looked to insulate markets from democracy altogether, solve the problem of voters and seek an economy shielded from popular sovereignty.
 


### PR DESCRIPTION
## Editorial review: 2025-12-22-hayeks-bastards

### Copy-editor (2 errors)
- "Crack Up Capitalism" → "Crack-Up Capitalism" (missing hyphen, L9)
- Orphaned "In" removed: "In Hayek's Bastards places them" → "Hayek's Bastards places them" (L18)

### Fact-check
- *Hayek's Bastards: Race, Gold, IQ, and the Capitalism of the Far Right* by Quinn Slobodian confirmed via Calibre
- *Crack-Up Capitalism* title and hyphenation confirmed via EPUB

Version bump: 1.0.0 → 1.0.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)