### PR TITLE
fix: editorial review — the-karla-trilogy

### DIFF
--- a/_posts/2025-11-25-the-karla-trilogy.md
+++ b/_posts/2025-11-25-the-karla-trilogy.md
@@ -6,7 +6,7 @@ categories: review book
 version: 1.0.0
 ---
 
-## Tinker Tailor Soldier Spy, The Honourable Schoolboy and Smiley's People
+## Tinker, Tailor, Soldier, Spy, The Honourable Schoolboy and Smiley's People
 
 These books are not new, around fifty years old as I write, yet they feel unexpectedly fresh.
 

--- a/_posts/2025-11-25-the-karla-trilogy.md
+++ b/_posts/2025-11-25-the-karla-trilogy.md
@@ -3,7 +3,7 @@ layout: post
 title: The Karla Trilogy
 date: 2025-11-25T20:30:00.000+00:00
 categories: review book
-version: 1.0.0
+version: 1.0.1
 ---
 
 ## Tinker, Tailor, Soldier, Spy, The Honourable Schoolboy and Smiley's People


### PR DESCRIPTION
## Editorial review: 2025-11-25-the-karla-trilogy

### Copy-editor (1 error)
- Missing commas in title heading: "Tinker Tailor Soldier Spy" → "Tinker, Tailor, Soldier, Spy" (L9)

### Fact-check
- All three le Carré novels confirmed via Calibre (IDs 52, 54, 55)
- Publication dates confirmed (~50 years old as of 2025)
- **Open item**: Guardian quote (L29) unverifiable — URL access-blocked, not in novel EPUBs (it's a reviewer characterisation). Link and attribution appear plausible.

Version bump: 1.0.0 → 1.0.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)