### PR TITLE
fix: editorial review of the-employees

### DIFF
--- a/_posts/2025-12-13-the-employees.md
+++ b/_posts/2025-12-13-the-employees.md
@@ -8,7 +8,7 @@ version: 1.0.0
 
 So this book is intentionally confusing. Which is forgiveable as it's very short. I feel fine being asked to sit in discomfort so long as I know it's not going to be that way for all my reading time across a week or more.
 
-What we get those is strange, and I'll need to much over it for a while to get to the bottom of what I just read.
+What we get though is strange, and I'll need to mull over it for a while to get to the bottom of what I just read.
 
 I think it captures well the idea that it doesn't matter how mundane or extraordinary the nature of your tasks is. The logic of our world is that we sell our labour as employees, and that lens is prime for thinking about how we are seen and see ourselves.
 

--- a/_posts/2025-12-13-the-employees.md
+++ b/_posts/2025-12-13-the-employees.md
@@ -3,7 +3,7 @@ layout: post
 title: The Employees
 date: 2025-12-13T17:00:00.000+00:00
 categories: review book
-version: 1.0.0
+version: 1.0.1
 ---
 
 So this book is intentionally confusing. Which is forgiveable as it's very short. I feel fine being asked to sit in discomfort so long as I know it's not going to be that way for all my reading time across a week or more.


### PR DESCRIPTION
## Editorial review: _posts/2025-12-13-the-employees.md

### Copy-editor
- "get those" → "get though" (wrong word, L11)
- "much over" → "mull over" (wrong word, L11)

### Fact-checker
- Bibliographic details confirmed via Calibre EPUB (ID 53): *The Employees: A workplace novel of the 22nd century* by Olga Ravn, translated by Martin Aitken.
- No other verifiable factual claims in post.

### Version bump
1.0.0 → 1.0.1