### PR TITLE
fix: editorial review of the-fire-next-time

### DIFF
--- a/_posts/2026-02-27-the-fire-next-time.md
+++ b/_posts/2026-02-27-the-fire-next-time.md
@@ -3,7 +3,7 @@ layout: post
 title: The Fire Next Time
 date: 2026-02-26T19:00:00.000+00:00
 categories: review book
-version: 1.0.0
+version: 1.0.1
 ---
 
 I don't know James Baldwin, other than as an eloquent voice and an American writer.

--- a/_posts/2026-02-27-the-fire-next-time.md
+++ b/_posts/2026-02-27-the-fire-next-time.md
@@ -14,13 +14,13 @@ But it is instantly recognisable as a precursor. I can see now that Ta-Nehisi Co
 
 Partly in format, but also in how these books speak to white people about race.
 
-> They are, in effect, still trapped in a history which they do not understand; and until they understand it, they cannot be released from it. They have had to believe for so many years, and for innumerable reasons, that black men are inferior to white men
+> They are, in effect, still trapped in a history which they do not understand; and until they understand it, they cannot be released from it. They have had to believe for many years, and for innumerable reasons, that black men are inferior to white men
 
 To be trapped in a history which you do not understand feels like a curse of mythic and ancient proportions.
 
 I find it difficult not to admire the unreasonable magnanimity of believing your oppressors can be better, that they are tragic in their mistake, and that they lose something of themselves as they take from others. He says:
 
-> Whoever debases another debases themselves
+> Whoever debases others is debasing himself
 
 There's an unflinching humanism in the writing. He asks for a coming together, but with those who might want to kill you. I wonder what America might have been if more solidarity had been extended on the basis of common means and not common race. As he puts it, the liberation of one is the liberation of the other.
 


### PR DESCRIPTION
## Editorial review: _posts/2026-02-27-the-fire-next-time.md

### Copy-editor
No errors found.

### Fact-checker
Three Baldwin blockquotes verified against Calibre EPUB (ID 57):

- **Q1 (L17):** "for so many years" → "for many years" (spurious "so")
- **Q2 (L23):** "Whoever debases another debases themselves" → "Whoever debases others is debasing himself" (wording diverged from source)
- **Q3 (L27):** Exact match ✓

### Version bump
1.0.0 → 1.0.1