### PR TITLE
fix(cms): change version widget from number to string

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -25,7 +25,7 @@ collections:
       - { label: 'Publish Date', name: 'date', widget: 'datetime' }
       - { label: 'Categories', name: 'categories', widget: 'list', default: ["review", "book"] }
       - { label: 'Books Reviewed', name: 'books_reviewed', widget: 'list', hint: 'URLs of _books/ entries covered by this review, e.g. /review/book/2020/04/12/wolf-hall/' }
-      - { label: 'Version', name: 'version', value_type: float, widget: 'number', default: 1.0.0 }
+      - { label: 'Version', name: 'version', widget: 'string', default: '1.0.0' }
       - { label: 'Body', name: 'body', widget: 'markdown' }
   - label: "Pages"
     name: "pages"
@@ -58,5 +58,6 @@ collections:
       - { label: "Rating", name: "rating", widget: "number", required: false }
       - { label: "Publish Date", name: "date", widget: "datetime", hint: "Controls the URL — set to date finished" }
       - { label: "Categories", name: "categories", widget: "hidden", default: "review book" }
+      - { label: "Version", name: "version", widget: "string", default: "1.0.0" }
       - { label: "Redirect From", name: "redirect_from", widget: "list", required: false, hint: "Old URLs that should redirect here" }
       - { label: "Body", name: "body", widget: "markdown", required: false, hint: "Leave blank if covered by a multi-book review" }


### PR DESCRIPTION
## Summary

Fixes #85.

Semver strings like `1.0.0` have two decimal points and are not valid floats, so DecapCMS's `number` widget rejects them when trying to create a new entry.

- Changed `version` field in the `reviews` collection from `widget: 'number', value_type: float` to `widget: 'string'`
- Added `version` as a `string` widget to the `books` collection (it was missing, though all book files use it)

## Test plan

- [ ] Open DecapCMS and create a new book entry — version field accepts `1.0.0` without error
- [ ] Create a new multi-book review — version field accepts `1.0.0` without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)