### PR TITLE
fix(cms): change categories widget from list to hidden string

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -23,7 +23,7 @@ collections:
       - { label: 'Layout', name: 'layout', widget: 'hidden', default: 'review' }
       - { label: 'Title', name: 'title', widget: 'string' }
       - { label: 'Publish Date', name: 'date', widget: 'datetime' }
-      - { label: 'Categories', name: 'categories', widget: 'list', default: ["review", "book"] }
+      - { label: 'Categories', name: 'categories', widget: 'hidden', default: 'review book' }
       - { label: 'Books Reviewed', name: 'books_reviewed', widget: 'list', hint: 'URLs of _books/ entries covered by this review, e.g. /review/book/2020/04/12/wolf-hall/' }
       - { label: 'Version', name: 'version', value_type: float, widget: 'number', default: 1.0.0 }
       - { label: 'Body', name: 'body', widget: 'markdown' }


### PR DESCRIPTION
## Summary

Fixes #84.

Every file in `_books/` and `_reviews/` uses `categories: review book` as a space-separated string. The `list` widget in the reviews collection was emitting a YAML array instead, inconsistent with all existing content.

Changed to `widget: 'hidden'` with `default: 'review book'` — matching the books collection and all real files. Since categories never vary, hiding the field also removes unnecessary UI noise.

## Test plan

- [ ] Open DecapCMS and create a new multi-book review — the generated file should have `categories: review book` (string), not a YAML list

🤖 Generated with [Claude Code](https://claude.com/claude-code)