### PR TITLE
fix(cms): store publish date as YYYY-MM-DD not Zulu datetime

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -22,7 +22,7 @@ collections:
     fields:
       - { label: 'Layout', name: 'layout', widget: 'hidden', default: 'review' }
       - { label: 'Title', name: 'title', widget: 'string' }
-      - { label: 'Publish Date', name: 'date', widget: 'datetime' }
+      - { label: 'Publish Date', name: 'date', widget: 'datetime', format: 'YYYY-MM-DD', date_format: 'YYYY-MM-DD', time_format: false }
       - { label: 'Categories', name: 'categories', widget: 'hidden', default: 'review book' }
       - { label: 'Books Reviewed', name: 'books_reviewed', widget: 'list', hint: 'URLs of _books/ entries covered by this review, e.g. /review/book/2020/04/12/wolf-hall/' }
       - { label: 'Version', name: 'version', widget: 'string', default: '1.0.0' }
@@ -56,7 +56,7 @@ collections:
       - { label: "Date Started", name: "date_started", widget: "datetime" }
       - { label: "Date Finished", name: "date_finished", widget: "datetime", required: false }
       - { label: "Rating", name: "rating", widget: "number", required: false }
-      - { label: "Publish Date", name: "date", widget: "datetime", hint: "Controls the URL — set to date finished" }
+      - { label: "Publish Date", name: "date", widget: "datetime", format: "YYYY-MM-DD", date_format: "YYYY-MM-DD", time_format: false, hint: "Controls the URL — set to date finished" }
       - { label: "Categories", name: "categories", widget: "hidden", default: "review book" }
       - { label: "Version", name: "version", widget: "string", default: "1.0.0" }
       - { label: "Redirect From", name: "redirect_from", widget: "list", required: false, hint: "Old URLs that should redirect here" }


### PR DESCRIPTION
## Summary

DecapCMS's `datetime` widget defaults to full ISO 8601 strings (e.g. `2026-06-13T12:00:00.000Z`). The `date` field drives the Jekyll permalink — a Zulu/offset string can cause the URL date to shift unexpectedly when Jekyll converts it under UTC.

Setting `format: 'YYYY-MM-DD'`, `date_format: 'YYYY-MM-DD'`, and `time_format: false` on the publish date field in both `books` and `reviews` collections stores a plain date, consistent with all existing content and the historical convention.

`date_started` and `date_finished` are left as full datetimes — they record precise reading timestamps where the time component is meaningful.

## Test plan

- [ ] Create a new book entry in DecapCMS — `date` frontmatter is written as `2026-06-13`, not `2026-06-13T12:00:00.000Z`
- [ ] The generated filename uses the correct date in the slug

🤖 Generated with [Claude Code](https://claude.com/claude-code)