### PR TITLE
feat(books): publish Against Money review

### DIFF
--- a/_books/2026-05-30-against-money.md
+++ b/_books/2026-05-30-against-money.md
@@ -1,5 +1,5 @@
 ---
-date_finished: 2026-05-30T19:22:24.000+01:00
+layout: book
 title: "Against Money"
 authors:
   - J. W. Mason
@@ -8,6 +8,10 @@ work_iri: https://www.wikidata.org/wiki/Q
 edition_iri: https://www.wikidata.org/wiki/Q
 date_started: 2026-05-25T14:54:57.000+01:00
 rating: 5
+date: 2026-06-13 # Date Reviewed
+date_finished: 2026-05-30T19:22:24.000+01:00
+categories: review book
+version: 1.0.0
 ---
 
 ## How do you price a Freddo?


### PR DESCRIPTION
## What

Adds the publish frontmatter to the *Against Money* (Mason & Jayadev) book review so Jekyll renders and lists it: `layout`, `date` (review date), `categories`, and an initial `version: 1.0.0`.

## Why

The review body was merged to `main` separately (as `6d89b6f`), but without these house-style fields the entry won't render or appear in the books collection.

## Notes

- `work_iri` / `edition_iri` are intentionally left as placeholders — no Wikidata item exists for the book yet. Backfilling is deferred to a planned Wikidata IRI skill.
- Branch was rebased onto `main` so the already-merged body commit drops out; this PR is the frontmatter change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)