### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete string escaping or encoding

### DIFF
--- a/scripts/build_narrator_cache.rb
+++ b/scripts/build_narrator_cache.rb
@@ -52,7 +52,7 @@ puts "  #{names_to_resolve.size} to resolve"
 
 puts "\nPhase 1: exact label SPARQL for #{names_to_resolve.size} names..."
 
-label_values = names_to_resolve.map { |n| "\"#{n.gsub('"', '\\"')}\"@en" }.join(" ")
+label_values = names_to_resolve.map { |n| "\"#{n.gsub('\\', '\\\\').gsub('"', '\\"')}\"@en" }.join(" ")
 
 exact_results = sparql.query(<<~SPARQL)
   SELECT ?item ?name ?itemDescription WHERE {


### PR DESCRIPTION
Potential fix for [https://github.com/huwd/huwdiprose.co.uk/security/code-scanning/1](https://github.com/huwd/huwdiprose.co.uk/security/code-scanning/1)

The safest fix without changing behavior is to perform complete SPARQL string-literal escaping at the construction point on line 55 by escaping backslashes first, then double quotes.

In `scripts/build_narrator_cache.rb`, replace:
- `n.gsub('"', '\\"')`
with:
- `n.gsub('\\', '\\\\').gsub('"', '\\"')`

This preserves existing logic (still builds `"...“@en` values), but prevents backslashes in input from breaking escaping. No new methods or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
