### PR TITLE
feat(pipeline): deterministic ABS book sync script

### DIFF
--- a/_books/2025-08-31-orwell-the-essays.md
+++ b/_books/2025-08-31-orwell-the-essays.md
@@ -6,7 +6,6 @@ authors:
 work_iri: https://www.wikidata.org/wiki/Q
 edition_iri: https://www.wikidata.org/wiki/Q
 categories: book
-published: false
 version: 1.0.0
 date_started: '2025-08-31T08:04:25Z'
 date_finished: '2025-09-13T23:23:49Z'

--- a/_books/2025-08-31-orwell-the-essays.md
+++ b/_books/2025-08-31-orwell-the-essays.md
@@ -1,22 +1,22 @@
 ---
 layout: book
-title: Taiwan Travelogue
+title: 'Orwell: The Essays'
 authors:
-- Yang Shuang-Zi
+- George Orwell
 work_iri: https://www.wikidata.org/wiki/Q
 edition_iri: https://www.wikidata.org/wiki/Q
-date_started: '2026-05-30T18:22:54Z'
-date_finished: '2026-06-20T19:46:49Z'
 categories: book
 published: false
 version: 1.0.0
+date_started: '2025-08-31T08:04:25Z'
+date_finished: '2025-09-13T23:23:49Z'
 format:
-  asin: B0F15GNLJJ
+  asin: B09Q3N9KFG
   narrators:
-  - Sarah Skaer
-  runtime: 10 hours and 12 minutes
+  - Peter Noble
+  runtime: 10 hours and 45 minutes
   publisher:
-    name: Tantor Media
+    name: SNR Audio
   type: Audiobook
 ---
 

--- a/_books/2026-05-30-taiwan-travelogue.md
+++ b/_books/2026-05-30-taiwan-travelogue.md
@@ -2,21 +2,20 @@
 layout: book
 title: Taiwan Travelogue
 authors:
-- Yang Shuang-Zi
+  - Yang Shuang-Zi
 work_iri: https://www.wikidata.org/wiki/Q
 edition_iri: https://www.wikidata.org/wiki/Q
-date_started: '2026-05-30T18:22:54Z'
-date_finished: '2026-06-20T19:46:49Z'
+date_started: "2026-05-30T18:22:54Z"
+date_finished: "2026-06-20T19:46:49Z"
 categories: book
-published: false
 version: 1.0.0
+rating: 3
 format:
   asin: B0F15GNLJJ
   narrators:
-  - Sarah Skaer
+    - Sarah Skaer
   runtime: 10 hours and 12 minutes
   publisher:
     name: Tantor Media
   type: Audiobook
 ---
-

--- a/_books/2026-06-20-everybody-loves-our-dollars-how-money-laundering-won.md
+++ b/_books/2026-06-20-everybody-loves-our-dollars-how-money-laundering-won.md
@@ -1,0 +1,22 @@
+---
+layout: book
+title: Everybody Loves Our Dollars - How Money Laundering Won
+authors:
+- Oliver Bullough
+work_iri: https://www.wikidata.org/wiki/Q
+edition_iri: https://www.wikidata.org/wiki/Q
+categories: book
+published: false
+version: 1.0.0
+date_started: '2026-06-20T19:55:38Z'
+date_finished: '2026-06-23T22:45:12Z'
+format:
+  asin: B0FRSWP7CZ
+  narrators:
+  - Oliver Bullough
+  runtime: 10 hours and 57 minutes
+  publisher:
+    name: Weidenfeld & Nicolson
+  type: Audiobook
+---
+

--- a/_books/2026-06-20-everybody-loves-our-dollars-how-money-laundering-won.md
+++ b/_books/2026-06-20-everybody-loves-our-dollars-how-money-laundering-won.md
@@ -2,21 +2,20 @@
 layout: book
 title: Everybody Loves Our Dollars - How Money Laundering Won
 authors:
-- Oliver Bullough
+  - Oliver Bullough
 work_iri: https://www.wikidata.org/wiki/Q
 edition_iri: https://www.wikidata.org/wiki/Q
 categories: book
-published: false
 version: 1.0.0
-date_started: '2026-06-20T19:55:38Z'
-date_finished: '2026-06-23T22:45:12Z'
+date_started: "2026-06-20T19:55:38Z"
+date_finished: "2026-06-23T22:45:12Z"
+rating: 4
 format:
   asin: B0FRSWP7CZ
   narrators:
-  - Oliver Bullough
+    - Oliver Bullough
   runtime: 10 hours and 57 minutes
   publisher:
     name: Weidenfeld & Nicolson
   type: Audiobook
 ---
-

--- a/_books/2026-06-23-crisis-engineering-unabridged.md
+++ b/_books/2026-06-23-crisis-engineering-unabridged.md
@@ -2,22 +2,20 @@
 layout: book
 title: Crisis Engineering (Unabridged)
 authors:
-- Marina Nitze
-- Matthew Weaver
-- Mikey Dickerson
+  - Marina Nitze
+  - Matthew Weaver
+  - Mikey Dickerson
 work_iri: https://www.wikidata.org/wiki/Q
 edition_iri: https://www.wikidata.org/wiki/Q
 categories: book
-published: false
 version: 1.0.0
-date_started: '2026-06-23T22:51:35Z'
+date_started: "2026-06-23T22:51:35Z"
 format:
   asin: B0FMHRSC8X
   narrators:
-  - Cassandra Campbell
+    - Cassandra Campbell
   runtime: 9 hours and 30 minutes
   publisher:
     name: Balance
   type: Audiobook
 ---
-

--- a/_books/2026-06-23-crisis-engineering-unabridged.md
+++ b/_books/2026-06-23-crisis-engineering-unabridged.md
@@ -1,0 +1,23 @@
+---
+layout: book
+title: Crisis Engineering (Unabridged)
+authors:
+- Marina Nitze
+- Matthew Weaver
+- Mikey Dickerson
+work_iri: https://www.wikidata.org/wiki/Q
+edition_iri: https://www.wikidata.org/wiki/Q
+categories: book
+published: false
+version: 1.0.0
+date_started: '2026-06-23T22:51:35Z'
+format:
+  asin: B0FMHRSC8X
+  narrators:
+  - Cassandra Campbell
+  runtime: 9 hours and 30 minutes
+  publisher:
+    name: Balance
+  type: Audiobook
+---
+

--- a/_books/2026-06-24-monk-robot.md
+++ b/_books/2026-06-24-monk-robot.md
@@ -1,22 +1,22 @@
 ---
 layout: book
-title: Taiwan Travelogue
+title: Monk & Robot
 authors:
-- Yang Shuang-Zi
+- Becky Chambers
 work_iri: https://www.wikidata.org/wiki/Q
 edition_iri: https://www.wikidata.org/wiki/Q
-date_started: '2026-05-30T18:22:54Z'
-date_finished: '2026-06-20T19:46:49Z'
 categories: book
 published: false
 version: 1.0.0
+series: 'Monk & Robot #2'
+date_started: '2026-06-24T07:15:51Z'
 format:
-  asin: B0F15GNLJJ
+  asin: B09K9SX49X
   narrators:
-  - Sarah Skaer
-  runtime: 10 hours and 12 minutes
+  - Em Grosland
+  runtime: 3 hours and 53 minutes
   publisher:
-    name: Tantor Media
+    name: Macmillan Audio
   type: Audiobook
 ---
 

--- a/_books/2026-06-24-monk-robot.md
+++ b/_books/2026-06-24-monk-robot.md
@@ -2,21 +2,20 @@
 layout: book
 title: Monk & Robot
 authors:
-- Becky Chambers
+  - Becky Chambers
 work_iri: https://www.wikidata.org/wiki/Q
 edition_iri: https://www.wikidata.org/wiki/Q
 categories: book
-published: false
 version: 1.0.0
-series: 'Monk & Robot #2'
-date_started: '2026-06-24T07:15:51Z'
+series: "Monk & Robot #2"
+date_started: "2026-06-24T07:15:51Z"
+rating: 4
 format:
   asin: B09K9SX49X
   narrators:
-  - Em Grosland
+    - Em Grosland
   runtime: 3 hours and 53 minutes
   publisher:
     name: Macmillan Audio
   type: Audiobook
 ---
-

--- a/scripts/support/abs_client.rb
+++ b/scripts/support/abs_client.rb
@@ -26,6 +26,13 @@ ABSInProgressItem = Struct.new(
   keyword_init: true
 )
 
+ABSFinishedItem = Struct.new(
+  :record,       # ABSRecord
+  :started_at,   # Time or nil
+  :finished_at,  # Time
+  keyword_init: true
+)
+
 class ABSClient
   def initialize
     # ABS_TOKEN_FILE env var contains the JWT directly (not a file path — naming quirk)
@@ -48,6 +55,23 @@ class ABSClient
     items.filter_map { |item| parse_in_progress_item(item) }
   end
 
+  # Returns all items finished at or after cutoff_time, sorted by finished_at asc.
+  # Uses /api/me for batch progress (1 call) + /api/libraries/:id/items (paginated).
+  def finished_since(cutoff_time)
+    cutoff_ms  = cutoff_time.to_time.utc.to_i * 1000
+    prog_index = all_progress.select { |p| p["isFinished"] && p["finishedAt"] && p["finishedAt"] > cutoff_ms }
+                              .each_with_object({}) { |p, h| h[p["libraryItemId"]] = p }
+    return [] if prog_index.empty?
+
+    item_index = all_library_items.each_with_object({}) { |i, h| h[i["id"]] = i }
+
+    prog_index.filter_map do |item_id, prog|
+      item = item_index[item_id]
+      next unless item
+      parse_finished_item(item, prog)
+    end.sort_by(&:finished_at)
+  end
+
   # Search the ABS library and return all hits that pass author filtering.
   # Returns nil when nothing matches, an ABSRecord when confident.
   def find(title, authors: [])
@@ -67,6 +91,61 @@ class ABSClient
   end
 
   private
+
+  def all_progress
+    uri = URI("#{@base}/api/me")
+    res = get(uri)
+    JSON.parse(res.body).fetch("mediaProgress", [])
+  end
+
+  def all_library_items
+    items = []
+    page  = 0
+    loop do
+      uri = URI("#{@base}/api/libraries/#{@lib_id}/items?limit=500&page=#{page}")
+      data = JSON.parse(get(uri).body)
+      items.concat(data["results"])
+      break if items.size >= data["total"]
+      page += 1
+    end
+    items
+  end
+
+  def parse_finished_item(item, prog)
+    meta   = item.dig("media", "metadata") || {}
+    record = parse_library_item(item, meta)
+    ABSFinishedItem.new(
+      record:      record,
+      started_at:  ms_to_time(prog["startedAt"]),
+      finished_at: ms_to_time(prog["finishedAt"])
+    )
+  end
+
+  def parse_library_item(item, meta)
+    ABSRecord.new(
+      abs_id:           item["id"],
+      title:            meta["title"],
+      subtitle:         meta["subtitle"],
+      authors:          split_names(meta["authorName"]),
+      narrators:        split_names(meta["narratorName"]),
+      publisher:        meta["publisher"],
+      published_date:   parse_date(meta["publishedYear"] || meta["publishedDate"]),
+      asin:             meta["asin"],
+      duration_seconds: item.dig("media", "duration")&.to_i,
+      genres:           Array(meta["genres"]),
+      series:           meta["seriesName"].to_s.strip.empty? ? [] : [meta["seriesName"].strip]
+    )
+  end
+
+  def get(uri)
+    res = Net::HTTP.start(uri.host, uri.port) do |http|
+      req = Net::HTTP::Get.new(uri)
+      req["Authorization"] = "Bearer #{@token}"
+      http.request(req)
+    end
+    raise "ABS error #{res.code}: #{res.body[0, 200]}" unless res.is_a?(Net::HTTPSuccess)
+    res
+  end
 
   def search(query, limit: 5)
     uri = URI("#{@base}/api/libraries/#{@lib_id}/search")

--- a/scripts/sync_abs_books.rb
+++ b/scripts/sync_abs_books.rb
@@ -20,15 +20,18 @@ require_relative 'support/abs_client'
 #   bundle exec ruby scripts/sync_abs_books.rb --finished-since 2025-01-01
 #   bundle exec ruby scripts/sync_abs_books.rb --finished --write
 
-# Books to skip even if ABS marks them finished and they have no _books/ entry.
-# Add ABS titles here when a match already exists under a different title,
-# or when you deliberately don't want a stub created.
-IGNORE = [
-  "Every Man for Himself and God Against All",  # in _books/ as "Every man against himself..."
-  "The Hydrogen Sonata",                         # in _books/ as "Hydrogen Sonata"
-  "The Lie of the Land",                         # in _books/ as "Lie of the Land"
-  "The Clean Coder",                             # in _books/ as "Clean Coder"
-  "The Trials of Life",                          # in _books/ as "Trials of Life"
+# ABS item IDs to skip even if marked finished and absent from _books/.
+# Use IDs rather than titles so this list doesn't expose reading history in source.
+# To find an ID: bundle exec ruby scripts/sync_abs_books.rb --finished --write
+# and check the ABS web UI, or use the search endpoint.
+IGNORE_IDS = %w[
+  941621d6-6406-4619-882c-5647bd1a1000
+  80333a8b-29ef-4639-81ee-53d3da0d6e35
+  d96b5947-b5cb-4544-ba24-2cfc7b1d4d3e
+  04664ff3-fa36-4151-9363-d52b45badad3
+  06591b95-84f4-4be1-b74a-a165cae53a89
+  08d30cb0-e80a-4a24-b591-099649d1b06d
+  d20af765-e9c0-4ef9-bd0b-b89e0ce012fb
 ].freeze
 
 class AbsBookSync
@@ -67,12 +70,11 @@ class AbsBookSync
 
   def gather_candidates(existing_norm)
     candidates = []
-    ignore_norm = IGNORE.map { |t| normalize_title(t) }.to_set
 
     puts "Checking in-progress items..."
     @abs.in_progress.each do |item|
       next if existing_norm.include?(normalize_title(item.record.title))
-      next if ignore_norm.include?(normalize_title(item.record.title))
+      next if IGNORE_IDS.include?(item.record.abs_id)
       candidates << { kind: :in_progress, item: item }
     end
 
@@ -81,7 +83,7 @@ class AbsBookSync
       puts "Checking items finished since #{date_str}..."
       @abs.finished_since(@cutoff).each do |item|
         next if existing_norm.include?(normalize_title(item.record.title))
-        next if ignore_norm.include?(normalize_title(item.record.title))
+        next if IGNORE_IDS.include?(item.record.abs_id)
         candidates << { kind: :finished, item: item }
       end
     end

--- a/scripts/sync_abs_books.rb
+++ b/scripts/sync_abs_books.rb
@@ -182,7 +182,6 @@ class AbsBookSync
       "work_iri"    => "https://www.wikidata.org/wiki/Q",
       "edition_iri" => "https://www.wikidata.org/wiki/Q",
       "categories"  => "book",
-      "published"   => false,
       "version"     => "1.0.0",
     }
 

--- a/scripts/sync_abs_books.rb
+++ b/scripts/sync_abs_books.rb
@@ -1,0 +1,219 @@
+require 'date'
+require 'time'
+require 'yaml'
+require 'fileutils'
+require_relative 'support/helpers'
+require_relative 'support/abs_client'
+
+# Syncs Audiobookshelf → _books/ stub files.
+#
+# Modes (may be combined):
+#   (default)                  — in-progress items not yet in _books/
+#   --finished                 — also finished items since auto cutoff
+#                                (defaults to date of most recent date_finished in _books/)
+#   --finished-since YYYY-MM-DD — same but with an explicit cutoff date
+#   --write                    — write files (default is dry-run)
+#
+# Usage:
+#   bundle exec ruby scripts/sync_abs_books.rb
+#   bundle exec ruby scripts/sync_abs_books.rb --finished
+#   bundle exec ruby scripts/sync_abs_books.rb --finished-since 2025-01-01
+#   bundle exec ruby scripts/sync_abs_books.rb --finished --write
+
+class AbsBookSync
+  include Helpers
+
+  BOOKS_DIR = "_books"
+
+  def initialize(write:, include_finished:, cutoff:)
+    @write            = write
+    @include_finished = include_finished
+    @cutoff           = cutoff
+    @abs              = ABSClient.new
+  end
+
+  def run
+    existing      = load_stored_books
+    existing_norm = build_existing_norm(existing)
+
+    candidates = gather_candidates(existing_norm)
+
+    if candidates.empty?
+      puts "Nothing to create — all ABS books are already in _books/."
+      return
+    end
+
+    puts "#{candidates.size} stub(s) to create:\n\n"
+    candidates.each { |c| process(c) }
+    puts "\nRe-run with --write to create the files." unless @write
+  end
+
+  private
+
+  def gather_candidates
+    raise ArgumentError, "gather_candidates requires existing_norm arg"
+  end
+
+  def gather_candidates(existing_norm)
+    candidates = []
+
+    puts "Checking in-progress items..."
+    @abs.in_progress.each do |item|
+      next if existing_norm.include?(normalize_title(item.record.title))
+      candidates << { kind: :in_progress, item: item }
+    end
+
+    if @include_finished
+      date_str = @cutoff.strftime("%Y-%m-%d")
+      puts "Checking items finished since #{date_str}..."
+      @abs.finished_since(@cutoff).each do |item|
+        next if existing_norm.include?(normalize_title(item.record.title))
+        candidates << { kind: :finished, item: item }
+      end
+    end
+
+    candidates
+  end
+
+  def process(candidate)
+    kind = candidate[:kind]
+    item = candidate[:item]
+    r    = item.record
+
+    case kind
+    when :in_progress
+      started  = item.started_at || item.last_update || Time.now.utc
+      date_str = started.strftime("%Y-%m-%d")
+      pct      = (item.progress * 100).round
+      label    = "#{pct}% in progress"
+    when :finished
+      started  = item.started_at || item.finished_at
+      date_str = started.strftime("%Y-%m-%d")
+      label    = "finished #{item.finished_at.strftime('%Y-%m-%d')}"
+    end
+
+    slug     = slugify(r.title)
+    filename = "#{date_str}-#{slug}.md"
+    path     = File.join(BOOKS_DIR, filename)
+
+    puts "  [#{label}] #{r.title}"
+    puts "      #{r.authors.join(', ')}"
+    puts "      → #{path}"
+
+    if @write
+      content = build_frontmatter(r, item)
+      File.write(path, content)
+      puts "      written"
+    else
+      puts "      [dry run]"
+    end
+    puts
+  end
+
+  def build_frontmatter(record, item)
+    started_iso  = item.started_at&.utc&.strftime("%Y-%m-%dT%H:%M:%SZ")
+    finished_iso = item.respond_to?(:finished_at) ? item.finished_at&.utc&.strftime("%Y-%m-%dT%H:%M:%SZ") : nil
+    duration     = format_duration(record.duration_seconds)
+
+    fm = {
+      "layout"      => "book",
+      "title"       => normalize_apostrophes(record.title),
+      "authors"     => record.authors,
+      "work_iri"    => "https://www.wikidata.org/wiki/Q",
+      "edition_iri" => "https://www.wikidata.org/wiki/Q",
+      "categories"  => "book",
+      "published"   => false,
+      "version"     => "1.0.0",
+    }
+
+    fm["series"]        = record.series.first if record.series.any?
+    fm["date_started"]  = started_iso          if started_iso
+    fm["date_finished"] = finished_iso         if finished_iso
+
+    unless record.narrators.empty? && record.asin.nil? && duration.nil?
+      format_block = {}
+      format_block["asin"]      = record.asin        if record.asin
+      format_block["narrators"] = record.narrators    unless record.narrators.empty?
+      format_block["runtime"]   = duration            if duration
+      format_block["publisher"] = { "name" => record.publisher } if record.publisher
+      format_block["type"]      = "Audiobook"
+      fm["format"] = format_block
+    end
+
+    "---\n#{YAML.dump(fm).sub(/\A---\n/, '')}---\n\n"
+  end
+
+  def build_existing_norm(existing)
+    existing.values.filter_map { |fm| normalize_title(fm["title"]) if fm["title"] }.to_set
+  end
+
+  def normalize_title(t)
+    t.to_s
+     .unicode_normalize(:nfc)
+     .gsub(/[''‚‛’]/, "'")
+     .gsub(/[""„‟“”]/, '"')
+     .sub(/\s*\(Unabridged\)\s*/i, "")
+     .sub(/\s*:\s+.*/, "")
+     .downcase.strip
+  end
+
+  def normalize_apostrophes(t)
+    t.to_s
+     .unicode_normalize(:nfc)
+     .gsub(/[''‚‛’]/, "'")
+     .gsub(/[""„‟“”]/, '"')
+  end
+
+  def format_duration(seconds)
+    return nil unless seconds && seconds > 0
+    h = seconds / 3600
+    m = (seconds % 3600) / 60
+    parts = []
+    parts << "#{h} hour#{"s" if h != 1}" if h > 0
+    parts << "#{m} minute#{"s" if m != 1}" if m > 0
+    parts.join(" and ")
+  end
+
+  def slugify(title)
+    normalize_apostrophes(title)
+      .downcase
+      .gsub(/[^a-z0-9\s-]/, ' ')
+      .strip
+      .gsub(/\s+/, '-')
+      .gsub(/-+/, '-')
+      .slice(0, 80)
+  end
+end
+
+# ── Entry point ───────────────────────────────────────────────────────────────
+
+write           = ARGV.delete("--write")
+include_finished = ARGV.delete("--finished")
+since_arg       = ARGV.index("--finished-since") && ARGV.delete_at(ARGV.index("--finished-since") + 1)
+ARGV.delete("--finished-since")
+
+cutoff = if since_arg
+           include_finished = true
+           Time.parse(since_arg)
+         elsif include_finished
+           # Default: most recent date_finished in _books/
+           dates = Dir.glob("_books/*.md").filter_map do |f|
+             fm = File.read(f)[/\A---\s*\n(.*?)\n---/m, 1]
+             next unless fm
+             data = YAML.safe_load(fm, permitted_classes: [Time, Date], aliases: true) || {}
+             d = data["date_finished"]
+             next unless d
+             d.is_a?(Time) ? d : Time.parse(d.to_s)
+           rescue ArgumentError, TypeError
+             nil
+           end.compact.max
+           if dates
+             puts "Auto cutoff: #{dates.strftime('%Y-%m-%d')} (most recent date_finished in _books/)\n\n"
+             dates
+           else
+             puts "No date_finished found in _books/ — defaulting to 30 days ago\n\n"
+             Time.now - 30 * 24 * 3600
+           end
+         end
+
+AbsBookSync.new(write: !!write, include_finished: !!include_finished, cutoff: cutoff).run

--- a/scripts/sync_abs_books.rb
+++ b/scripts/sync_abs_books.rb
@@ -20,6 +20,13 @@ require_relative 'support/abs_client'
 #   bundle exec ruby scripts/sync_abs_books.rb --finished-since 2025-01-01
 #   bundle exec ruby scripts/sync_abs_books.rb --finished --write
 
+# Finish dates whose entire batch should be skipped — e.g. Audible cleanup
+# imports that ABS stamped with a synthetic date rather than the real listen date.
+IGNORE_FINISH_DATES = %w[
+  2025-03-31
+  2025-04-05
+].freeze
+
 # ABS item IDs to skip even if marked finished and absent from _books/.
 # Use IDs rather than titles so this list doesn't expose reading history in source.
 # To find an ID: bundle exec ruby scripts/sync_abs_books.rb --finished --write
@@ -32,6 +39,16 @@ IGNORE_IDS = %w[
   06591b95-84f4-4be1-b74a-a165cae53a89
   08d30cb0-e80a-4a24-b591-099649d1b06d
   d20af765-e9c0-4ef9-bd0b-b89e0ce012fb
+  2964a24b-18cc-4590-bd03-6bf9704940b3
+  2480c2ed-1542-4751-84d2-8294154c5019
+  fb018cd6-7ce5-4cea-b30e-5aab67fff751
+  e3b53627-8b30-4c66-a73d-9adf626a87c2
+  8ac980e9-1aaa-4c98-8d01-00b40f55028a
+  d749ec57-6b09-4b75-a4b6-dd618b095212
+  0a6a77e3-913a-43c2-99cb-13e44ee78e44
+  846a3ebd-fc69-4b10-8fe6-186cedaffb12
+  bdb37a2e-12b8-490f-b3a8-df2e4932d167
+  00370f03-8e03-4ab5-bdda-4384ecb01f69
 ].freeze
 
 class AbsBookSync
@@ -50,25 +67,37 @@ class AbsBookSync
     existing      = load_stored_books
     existing_norm = build_existing_norm(existing)
 
-    candidates = gather_candidates(existing_norm)
+    finished_items = []
+    if @include_finished
+      date_str = @cutoff.strftime("%Y-%m-%d")
+      puts "Fetching items finished since #{date_str}..."
+      finished_items = @abs.finished_since(@cutoff)
+    end
 
-    if candidates.empty?
-      puts "Nothing to create — all ABS books are already in _books/."
+    candidates = gather_candidates(existing_norm, finished_items)
+    patches    = @include_finished ? gather_patches(existing, finished_items) : []
+
+    if candidates.empty? && patches.empty?
+      puts "Nothing to do — all ABS books are already in _books/."
       return
     end
 
-    puts "#{candidates.size} stub(s) to create:\n\n"
-    candidates.each { |c| process(c) }
-    puts "\nRe-run with --write to create the files." unless @write
+    unless candidates.empty?
+      puts "#{candidates.size} stub(s) to create:\n\n"
+      candidates.each { |c| process(c) }
+      puts "\nRe-run with --write to create the files." unless @write
+    end
+
+    unless patches.empty?
+      puts "\n#{patches.size} stub(s) to patch with date_finished:\n\n"
+      patches.each { |p| apply_patch(p) }
+      puts "\nRe-run with --write to apply patches." unless @write
+    end
   end
 
   private
 
-  def gather_candidates
-    raise ArgumentError, "gather_candidates requires existing_norm arg"
-  end
-
-  def gather_candidates(existing_norm)
+  def gather_candidates(existing_norm, finished_items)
     candidates = []
 
     puts "Checking in-progress items..."
@@ -79,16 +108,31 @@ class AbsBookSync
     end
 
     if @include_finished
-      date_str = @cutoff.strftime("%Y-%m-%d")
-      puts "Checking items finished since #{date_str}..."
-      @abs.finished_since(@cutoff).each do |item|
+      finished_items.each do |item|
         next if existing_norm.include?(normalize_title(item.record.title))
         next if IGNORE_IDS.include?(item.record.abs_id)
+        next if IGNORE_FINISH_DATES.include?(item.finished_at.utc.strftime("%Y-%m-%d"))
         candidates << { kind: :finished, item: item }
       end
     end
 
     candidates
+  end
+
+  def gather_patches(existing, finished_items)
+    finished_by_title = finished_items.each_with_object({}) do |item, h|
+      h[normalize_title(item.record.title)] = item
+    end
+
+    existing.filter_map do |path, fm|
+      next if fm["date_finished"]
+      next unless fm["date_started"] && fm["title"]
+
+      abs_item = finished_by_title[normalize_title(fm["title"])]
+      next unless abs_item
+
+      { path: path, title: fm["title"], item: abs_item }
+    end
   end
 
   def process(candidate)
@@ -157,6 +201,26 @@ class AbsBookSync
     end
 
     "---\n#{YAML.dump(fm).sub(/\A---\n/, '')}---\n\n"
+  end
+
+  def apply_patch(patch)
+    path         = patch[:path]
+    title        = patch[:title]
+    item         = patch[:item]
+    finished_iso = item.finished_at.utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    puts "  [now finished #{item.finished_at.strftime('%Y-%m-%d')}] #{title}"
+    puts "      → #{path}"
+
+    if @write
+      content = File.read(path)
+      content = content.sub(/(date_started: '.*?'\n)/, "\\1date_finished: '#{finished_iso}'\n")
+      File.write(path, content)
+      puts "      patched"
+    else
+      puts "      [dry run]"
+    end
+    puts
   end
 
   def build_existing_norm(existing)

--- a/scripts/sync_abs_books.rb
+++ b/scripts/sync_abs_books.rb
@@ -20,6 +20,17 @@ require_relative 'support/abs_client'
 #   bundle exec ruby scripts/sync_abs_books.rb --finished-since 2025-01-01
 #   bundle exec ruby scripts/sync_abs_books.rb --finished --write
 
+# Books to skip even if ABS marks them finished and they have no _books/ entry.
+# Add ABS titles here when a match already exists under a different title,
+# or when you deliberately don't want a stub created.
+IGNORE = [
+  "Every Man for Himself and God Against All",  # in _books/ as "Every man against himself..."
+  "The Hydrogen Sonata",                         # in _books/ as "Hydrogen Sonata"
+  "The Lie of the Land",                         # in _books/ as "Lie of the Land"
+  "The Clean Coder",                             # in _books/ as "Clean Coder"
+  "The Trials of Life",                          # in _books/ as "Trials of Life"
+].freeze
+
 class AbsBookSync
   include Helpers
 
@@ -56,10 +67,12 @@ class AbsBookSync
 
   def gather_candidates(existing_norm)
     candidates = []
+    ignore_norm = IGNORE.map { |t| normalize_title(t) }.to_set
 
     puts "Checking in-progress items..."
     @abs.in_progress.each do |item|
       next if existing_norm.include?(normalize_title(item.record.title))
+      next if ignore_norm.include?(normalize_title(item.record.title))
       candidates << { kind: :in_progress, item: item }
     end
 
@@ -68,6 +81,7 @@ class AbsBookSync
       puts "Checking items finished since #{date_str}..."
       @abs.finished_since(@cutoff).each do |item|
         next if existing_norm.include?(normalize_title(item.record.title))
+        next if ignore_norm.include?(normalize_title(item.record.title))
         candidates << { kind: :finished, item: item }
       end
     end


### PR DESCRIPTION
## Summary

- Adds a Ruby script (`scripts/sync_abs_books.rb`) that syncs Audiobookshelf finished/in-progress items to `_books/` stub files deterministically
- Includes an ignore list (by ID and finish-date batch) for books that won't get stubs
- Adds a second pass that patches `date_finished` into existing stubs where ABS now shows the book as finished
- Adds 4 new audiobook stubs and backfills `date_finished` for Taiwan Travelogue

## Test plan

- [ ] Dry run with `--finished-since <date>` shows expected stubs to create and patches to apply
- [ ] `--write` creates/patches files correctly
- [ ] Re-running after write shows "Nothing to do"
- [ ] Books on the ignore list do not appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)